### PR TITLE
Upgrade node-ignore -> 3.x to solve several known issues.

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -132,7 +132,7 @@ function IgnoredPaths(options) {
      * @returns {array} raw ignore rules
      */
     function addPattern(ig, pattern) {
-        return ig.addPattern(pattern);
+        return ig.add(pattern);
     }
 
     /**
@@ -142,21 +142,18 @@ function IgnoredPaths(options) {
      * @returns {array} raw ignore rules
      */
     function addIgnoreFile(ig, filepath) {
-        return ig.addIgnoreFile(filepath);
+        if (fs.existsSync(filepath)) {
+          ig.add(fs.readFileSync(filepath).toString());
+        }
+        return ig;
     }
 
     this.defaultPatterns = DEFAULT_IGNORE_PATTERNS.concat(options.patterns || []);
     this.baseDir = ".";
 
     this.ig = {
-        custom: new ignore.Ignore({
-            twoGlobstars: true,
-            ignore: []
-        }),
-        default: new ignore.Ignore({
-            twoGlobstars: true,
-            ignore: []
-        })
+        custom: ignore(),
+        default: ignore()
     };
 
     if (options.dotfiles !== true) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.5.1",
     "optionator": "^0.8.1",
     "shelljs": "^0.6.0",
-    "ignore": "^2.2.19",
+    "ignore": "^3.0.10",
     "table": "^3.7.8",
     "text-table": "~0.2.0",
     "pluralize": "^1.2.1",


### PR DESCRIPTION
Upgrades [`node-ignore`](https://www.npmjs.com/package/ignore) to the latest `3.0.10` to solve several known issues, including:
- Files should not be re-included if the parent directory is ignored, [#10](https://github.com/kaelzhang/node-ignore/issues/10)
- Works for [windows](https://ci.appveyor.com/project/kaelzhang/node-ignore), finally. [#5](https://github.com/kaelzhang/node-ignore/issues/5)
- Better Handling with trailing whitespaces, wildcards of ignore patterns, according to [gitignore spec](https://git-scm.com/docs/gitignore), and passed all cases described in the spec.

Seems there is no tests for `ignored-paths.js`
