### PR TITLE
Поиск по регулярке реального атрибута class

### DIFF
--- a/lib/bemlint.js
+++ b/lib/bemlint.js
@@ -12,8 +12,8 @@ var path            = require("path"),
     Message         = require("./message"),
     rules           = require("./rules"),
     cheerio         = require('cheerio'),
-    attrFoundInLine = /^(.*<.+?class=".+)$/gim,
-    attrClassRegex  = /class="(.+?)"/gim;
+    attrFoundInLine = /^(.*<.+?\s+class=".+)$/gim,
+    attrClassRegex  = /\s+class="(.+?)"/gim;
 
 
 /**


### PR DESCRIPTION
Если искать `/class="(.+?)"/gim`, захватятся и `data-sometext-class=""`, а не только `class=""`.
У меня ложные срабатывания именно на такие data-атрибуты :(